### PR TITLE
Only scan for .sql files

### DIFF
--- a/src/db/migrator.janet
+++ b/src/db/migrator.janet
@@ -76,11 +76,12 @@
 
 
 (defn- file-migration-map []
-  (->> (os/dir migrations-dir)
+  (as-> (os/dir migrations-dir) ?
+       (filter |(string/has-suffix? ".sql" $) ?)
        (mapcat |(tuple (-> (string/split "-" $)
                            (first))
-                       $))
-       (apply struct)))
+                       $) ?)
+       (apply struct ?)))
 
 
 (defn- db-versions []


### PR DESCRIPTION
Only scan for .sql files, to avoid picking up random detritus that editors might place in the db/migrations folder.