### PR TITLE
Use `returning *` when doing inserts for sqlite

### DIFF
--- a/src/db/sqlite/db.janet
+++ b/src/db/sqlite/db.janet
@@ -389,10 +389,9 @@
       (set params (put (table ;(kvs (args 0))) :db/table nil))
       (set options (struct ;(drop 1 args)))))
 
-  (->> (sql/insert table-name params options)
-       (execute2)
-       (last-inserted table-name)))
-
+  (-> (sql/insert table-name params options)
+      (query2 table-name)
+      (get 0)))
 
 (defn insert-all
   `Takes an optional db connection, a table name and an array of dictionaries,

--- a/src/db/sqlite/sql.janet
+++ b/src/db/sqlite/sql.janet
@@ -277,7 +277,8 @@
         sql (string "insert into " (snake-case table-name) " (" columns ") values (" vals ")")
         sql (if (options :on-conflict)
               (string sql " " (on-conflict-clause options))
-              sql)]
+              sql)
+        sql (string sql " returning *")]
     [sql ;(array/concat (sql-params params) (if (options :set) (sql-params (options :set)) @[]))]))
 
 

--- a/test/db/sqlite/db-test.janet
+++ b/test/db/sqlite/db-test.janet
@@ -52,7 +52,7 @@
 
 
   (test "upsert with nothing"
-    (is (deep= @{:id 1 :title "title 1" :db/table :post :author-id 1}
+    (is (deep= nil
                (db/insert :post
                           {:title "title 1" :author-id 1 :id 1}
                           :on-conflict :id
@@ -244,6 +244,21 @@
     (is (deep= @{:id 6 :title "title 6" :body "body 6" :db/table :post}
                (db/delete :post 6))))
 
+  (test "insert new row"
+    (is (deep= @{:id 8 :title "title 2" :db/table :post :author-id 2}
+               (db/insert :post {:title "title 2" :author-id 2}))))
+
+  (test "insert new row"
+    (is (deep= @{:id 9 :title "title 2" :db/table :post :author-id 2}
+               (db/insert :post {:title "title 2" :author-id 2}))))
+
+  (test "upsert second to last row inserted, expecting to get back the relevant row updated"
+    (is (deep= @{:id 8 :title "title 1" :db/table :post :author-id 2}
+               (db/insert :post
+                          {:title "title 1" :author-id 2 :id 8}
+                          :on-conflict :id
+                          :do :update
+                          :set {:title "title 1"}))))
 
   (test "delete all"
     (is (deep= @[] (do

--- a/test/db/sqlite/sql-test.janet
+++ b/test/db/sqlite/sql-test.janet
@@ -26,22 +26,22 @@
 
 
   (test "insert"
-    (is (= ["insert into account (name) values (?)" "joy"]
+    (is (= ["insert into account (name) values (?) returning *" "joy"]
            (sql/insert :account {:name "joy"}))))
 
 
   (test "insert with multiple params"
-    (is (= ["insert into account (password, name) values (?, ?)" "secret" "joy"]
+    (is (= ["insert into account (password, name) values (?, ?) returning *" "secret" "joy"]
            (sql/insert :account {:name "joy" :password "secret"}))))
 
 
   (test "insert with null param"
-    (is (= ["insert into account (name) values (?)" nil]
+    (is (= ["insert into account (name) values (?) returning *" nil]
            (sql/insert :account {:name 'null}))))
 
 
   (test "insert with multiple params with dashes"
-    (is (= ["insert into account (password, name, created_at) values (?, ?, ?)"
+    (is (= ["insert into account (password, name, created_at) values (?, ?, ?) returning *"
             "secret" "joy" "created-at"]
            (sql/insert :account {:name "joy" :password "secret" :created-at "created-at"}))))
 


### PR DESCRIPTION
When running `db/insert` you expect to get back what you have inserted or updated. But since the return value is currently based on `sqlite3/last-insert-rowid` there is a case where the return value is unexpected. This edge case has been captured in the added tests.

You first insert two rows.
And then run another insert with `on conflict` where you only end up updating the first row you inserted. You expect to get back the row you modified, but before this change you will get back the second row.

There is one breaking change here, which is that if you do an insert where nothing is modified, you will get back `nil`. I think that makes sense.